### PR TITLE
Fix GNOME screen rotation after suspend/resume on GPD Pocket 4

### DIFF
--- a/hosts/personal/gpd/hardware.nix
+++ b/hosts/personal/gpd/hardware.nix
@@ -1,8 +1,21 @@
 # GPD Pocket 4 hardware (AMD Ryzen AI HX 370)
-{ inputs, ... }:
+{ inputs, pkgs, ... }:
 {
   imports = [ inputs.nixos-hardware.nixosModules.gpd-pocket-4 ];
 
   hardware.enableRedistributableFirmware = true;
   hardware.bluetooth.enable = true;
+
+  # After suspend/resume iio-sensor-proxy loses its accelerometer
+  # reading and falls back to the native panel orientation (portrait),
+  # flipping the display. Restarting it forces a fresh sensor read.
+  systemd.services.gpd-fix-resume-rotation = {
+    description = "Restart iio-sensor-proxy after resume to fix display rotation";
+    wantedBy = [ "post-resume.target" ];
+    after = [ "post-resume.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.systemd}/bin/systemctl restart iio-sensor-proxy.service";
+    };
+  };
 }


### PR DESCRIPTION
The IIO accelerometer (MXC6655) can report stale orientation data after
resume, causing GNOME to flip the display back to portrait. Add a systemd
oneshot service that restarts iio-sensor-proxy on post-resume.target to
force a fresh sensor read.

Uses ${pkgs.systemd}/bin/systemctl instead of a hardcoded path.

https://claude.ai/code/session_015bmSHVtV6bnbLBMia9EMf4